### PR TITLE
make intel iGPUs work

### DIFF
--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -23,6 +23,7 @@ pacman -Syu --noconfirm \
 	curl \
 	desktop-file-utils \
 	git \
+	intel-media-driver \
 	libfdk-aac \
 	libxtst \
 	obs-studio \

--- a/obs-appimage.sh
+++ b/obs-appimage.sh
@@ -59,6 +59,9 @@ cp -vn /usr/lib/obs-scripting/* ./shared/lib/obs-scripting
 ln ./sharun ./AppRun
 ./sharun -g
 
+# Make intel hardware accel work
+echo 'LIBVA_DRIVERS_PATH=${SHARUN_DIR}/shared/lib:${SHARUN_DIR}/shared/lib/dri' >> ./.env
+
 # MAKE APPIMAGE WITH URUNTIME
 cd ..
 wget --retry-connrefused --tries=30 "$URUNTIME"      -O  ./uruntime


### PR DESCRIPTION
Fixes intel iGPU hardware accel support by adding intel-media-driver pkg and echoing the correct libva drivers path